### PR TITLE
Add repoman run command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,6 @@
 import command from 'sb-command'
 import manifest from '../package.json'
 import RepoMan from './'
-import { BUILTIN_COMMANDS } from './helpers'
 
 require('process-bootstrap')('repoman')
 
@@ -17,10 +16,6 @@ function handleError(error) {
   }
   process.exit(1)
 }
-function isBuiltinCommand(entry: string) {
-  return BUILTIN_COMMANDS.has(entry.split(' ')[0])
-}
-
 RepoMan.get().then(function(repoMan) {
   // Basic setup
   command
@@ -30,8 +25,7 @@ RepoMan.get().then(function(repoMan) {
   const commands = repoMan.getCommands()
 
   function registerCommand(entry) {
-    const prefix = isBuiltinCommand(entry.name) ? '' : 'run.'
-    command.command(`${prefix}${entry.name}`, entry.description, (...params) => entry.run(...params))
+    command.command(entry.name, entry.description, (...params) => entry.run(...params))
     entry.options.forEach((option) => {
       // $FlowIgnore: Flow doens't like that I'm merging tuples, but I know what I'm doing
       command.option(option[0], option[1], option[2])
@@ -41,10 +35,8 @@ RepoMan.get().then(function(repoMan) {
 
   // Global options
   command.option('--debug', 'Enable debugging', false)
-  // First register builtin commands
-  commands.filter(c => isBuiltinCommand(c.name)).forEach(registerCommand)
-  // Then register non-builtin commands
-  commands.filter(c => !isBuiltinCommand(c.name)).forEach(registerCommand)
+  // Commands
+  commands.forEach(registerCommand)
 
   // Run it
   return command.process()

--- a/src/command/index.js
+++ b/src/command/index.js
@@ -175,7 +175,7 @@ export default class Command {
         PATH: [options.env.PATH, Path.join(options.cwd, 'node_modules', '.bin')].join(Path.delimiter),
       })
     }
-    if (project) {
+    if (project && project.path !== options.cwd) {
       options.env = Object.assign(options.env, {
         PATH: [options.env.PATH, Path.join(project.path, 'node_modules', '.bin')].join(Path.delimiter),
       })

--- a/src/commands/ExecCommand.js
+++ b/src/commands/ExecCommand.js
@@ -41,13 +41,13 @@ export default class ExecCommand extends Command {
     if (options.parallel) {
       await Promise.all(projects.map(project => this.spawn(command, parameters, {
         cwd: project.path,
-        stdio: ['inherit', 'inherit', 'inherit'],
+        stdio: 'inherit',
       }, project)))
     } else {
       for (const project of projects) {
         await this.spawn(command, parameters, {
           cwd: project.path,
-          stdio: ['inherit', 'inherit', 'inherit'],
+          stdio: 'inherit',
         }, project)
       }
     }
@@ -66,13 +66,13 @@ export default class ExecCommand extends Command {
     if (options.parallel) {
       await Promise.all(packages.map(pkg => this.spawn(command, parameters, {
         cwd: pkg.path,
-        stdio: ['inherit', 'inherit', 'inherit'],
+        stdio: 'inherit',
       }, pkg.project)))
     } else {
       for (const pkg of packages) {
         await this.spawn(command, parameters, {
           cwd: pkg.path,
-          stdio: ['inherit', 'inherit', 'inherit'],
+          stdio: 'inherit',
         }, pkg.project)
       }
     }

--- a/src/commands/LinkCommand.js
+++ b/src/commands/LinkCommand.js
@@ -52,7 +52,7 @@ export default class LinkCommand extends Command {
       this.log(`Linking ${this.helpers.tildify(pkg.path)}`)
       await this.spawn('npm', ['link'], {
         cwd: pkg.path,
-        stdio: ['inherit', 'inherit', 'inherit'],
+        stdio: 'inherit',
       }, pkg.project)
     }
   }

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,0 +1,20 @@
+// @flow
+
+import Command from '../command'
+
+export default class RunCommand extends Command {
+  name = 'run <script> [parameters...]'
+  description = 'Run the specified npm script in current project root (regardless of wherever you are in the project)'
+
+  async run(options: Object, script: string, parameters: Array<string>) {
+    const currentProject = await this.getCurrentProject()
+    const npmParameters = ['run', script]
+    if (parameters.length) {
+      npmParameters.push('--', ...parameters)
+    }
+    await this.spawn('npm', npmParameters, {
+      cwd: currentProject.path,
+      stdio: 'inherit',
+    }, currentProject)
+  }
+}

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -7,6 +7,7 @@ import Sync from './SyncCommand'
 import Eject from './EjectCommand'
 import Init from './InitCommand'
 import Exec from './ExecCommand'
+import Run from './RunCommand'
 import Publish from './PublishCommand'
 import Link from './LinkCommand'
 
@@ -18,6 +19,7 @@ export default [
   Eject,
   Init,
   Exec,
+  Run,
   Publish,
   Link,
 ]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,18 +6,6 @@ import expandTilde from 'expand-tilde'
 import type { Options, ParsedRepo } from './types'
 
 export const CONFIG_FILE_NAME = '.repoman.json'
-export const BUILTIN_COMMANDS = new Set([
-  'get',
-  'get.config',
-  'status',
-  'sync',
-  'exec',
-  'bootstrap',
-  'publish',
-  'eject',
-  'init',
-  'link',
-])
 export const CONFIG_DEFAULT_VALUE = {
   packages: ['./'],
   dependencies: [],


### PR DESCRIPTION
This command is useful when you are deep in a project, but don't want to go up and execute a script like `npm run watch`, you can just do `repoman run watch` regardless of your cwd in the project